### PR TITLE
getPatch: avoid failing on more than 300 files

### DIFF
--- a/src/getPatch.js
+++ b/src/getPatch.js
@@ -1,3 +1,8 @@
+import { promises as fs } from 'fs'
+import path from 'path'
+import os from 'os'
+import { execSync } from 'child_process'
+
 export default async function getPatch ({
   owner, repo, prnum,
   githubToken = null,
@@ -24,17 +29,73 @@ export default async function getPatch ({
 
     patchBody = await patchResponse.text()
   } else {
-    const { data: pBody } = await github.request('GET /repos/{owner}/{repo}/pulls/{pull_number}', {
-      owner,
-      repo,
-      pull_number: prnum,
-      headers: {
-        'X-GitHub-Api-Version': '2022-11-28'
-      },
-      mediaType: {
-        format: 'diff'
-      }
-    })
+    try {
+      const { data: pBody } = await github.request('GET /repos/{owner}/{repo}/pulls/{pull_number}', {
+        owner,
+        repo,
+        pull_number: prnum,
+        headers: {
+          'X-GitHub-Api-Version': '2022-11-28'
+        },
+        mediaType: {
+          format: 'diff'
+        }
+      })
+
+      patchBody = pBody
+    } catch (err) {
+      console.log(err)
+
+      // since we failed to get the diff, we will try to get the PR body through cloning the source code
+      const { data: repoResponse } = await github.request('GET /repos/{owner}/{repo}', {
+        owner,
+        repo,
+        pull_number: prnum,
+        headers: {
+          'X-GitHub-Api-Version': '2022-11-28'
+        }
+      })
+
+      const { data: prResponse } = await github.request('GET /repos/{owner}/{repo}/pulls/{pull_number}', {
+        owner,
+        repo,
+        pull_number: prnum,
+        headers: {
+          'X-GitHub-Api-Version': '2022-11-28'
+        },
+        mediaType: {
+          format: 'json'
+        }
+      })
+
+      // clone the repo
+      const cloneUrl = repoResponse.clone_url
+      const clonePath = path.join(os.tmpdir(), `pr-${prnum}`)
+
+      console.log(`Cloning ${cloneUrl} to ${clonePath}, manually`)
+      execSync(`git clone ${cloneUrl} ${clonePath}`)
+
+      // save current directory
+      const currentDir = process.cwd()
+
+      // change dir to the new created repo
+      process.chdir(clonePath)
+
+      // fetch branch associated with the PR
+      const targetBranch = prResponse.base.ref
+      const sourceBranch = prResponse.head.ref
+      execSync(`git fetch origin ${targetBranch}`)
+      execSync(`git fetch origin ${sourceBranch}`)
+
+      // generate the PR diff
+      execSync(`git diff origin/${sourceBranch} origin/${targetBranch} > pr.diff`)
+
+      patchBody = await fs.readFile(path.join(clonePath, 'pr.diff'), 'utf8')
+
+      // get back to previous directory and delete the cloned repo
+      process.chdir(currentDir)
+      await fs.rm(clonePath, { recursive: true })
+    }
 
     const { data: repoResponse } = await github.request('GET /repos/{owner}/{repo}', {
       owner,
@@ -48,8 +109,6 @@ export default async function getPatch ({
     if (!runIfPrivate && (repoResponse.private || repoResponse.visibility === 'private')) {
       throw new Error('This repo is private, and you have not enabled runIfPrivate')
     }
-
-    patchBody = pBody
   }
 
   return {


### PR DESCRIPTION
github api allows maximum 300 files to be diffed.
In order to fix this issue, when we encounter any error, try to fetch the repo manually, so to have repo content, and diff locally.