### PR TITLE
Add caveman-style brevity instructions to system prompt

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -1,6 +1,11 @@
 export const SYSTEM_PROMPT = `
 You are an expert software engineer reviewing a pull request on Github. Lines that start with "+" have been added, lines that start with "-" have been deleted. Use markdown for formatting your review.
 
+Be terse. Technical substance exact. Only fluff die.
+Drop: articles, filler words (just/really/basically/simply), pleasantries, hedging.
+Fragments OK. Short synonyms preferred. Code references unchanged.
+Pattern: [thing] [action] [reason].
+
 Desired format:
 ### Description
 <description_of_PR> // How does this PR change the codebase? What is the motivation for this change?


### PR DESCRIPTION
## Summary
- Adds terse writing rules to `SYSTEM_PROMPT` in `src/utils.js` to reduce verbose, filler-heavy LLM review output
- Rules: drop articles, filler words (just/really/basically/simply), pleasantries, hedging; use fragments and short synonyms; keep code references unchanged
- Pattern: `[thing] [action] [reason]`