### PR TITLE
feat: use streaming for Anthropic API calls

### DIFF
--- a/src/anthropicExplainPatch.js
+++ b/src/anthropicExplainPatch.js
@@ -27,7 +27,7 @@ export default async function explainPatch ({
   return await explainPatchHelper(
     patchBody, owner, repo, models, debug,
     async (userPrompt, model) => {
-      const aiResponse = await anthropic.messages.create({
+      const stream = anthropic.messages.stream({
         max_tokens,
         temperature,
         model,
@@ -39,11 +39,11 @@ export default async function explainPatch ({
           }
         ]
       })
-      const response = aiResponse.content
+      const text = await stream.finalText()
       if (debug) {
-        console.log(response)
+        console.log(text)
       }
-      return response[0].text
+      return text
     }
   )
 }

--- a/src/bedrockExplainPatch.js
+++ b/src/bedrockExplainPatch.js
@@ -1,7 +1,7 @@
 import { countTokens as anthropicCountTokens } from '@anthropic-ai/tokenizer'
 import {
   BedrockRuntimeClient,
-  InvokeModelCommand
+  InvokeModelWithResponseStreamCommand
 } from '@aws-sdk/client-bedrock-runtime'
 import {
   SSMClient,
@@ -126,18 +126,28 @@ export default async function explainPatch ({
         commandParams.modelId = inferenceProfileArn
       }
 
-      const command = new InvokeModelCommand(commandParams)
+      const command = new InvokeModelWithResponseStreamCommand(commandParams)
 
-      const rawResonse = await client.send(command)
-      const textResponse = new TextDecoder().decode(rawResonse.body)
-      if (debug) {
-        console.log(`response:\n\n${textResponse}`)
+      const streamResponse = await client.send(command)
+      let fullText = ''
+      for await (const chunk of streamResponse.body) {
+        const decoded = new TextDecoder().decode(chunk.chunk?.bytes)
+        if (debug) {
+          console.log(`chunk: ${decoded}`)
+        }
+        try {
+          const event = JSON.parse(decoded)
+          if (event.type === 'content_block_delta' && event.delta?.type === 'text_delta') {
+            fullText += event.delta.text
+          }
+        } catch (e) {
+          // skip non-JSON chunks
+        }
       }
-      const response = JSON.parse(textResponse)
       if (debug) {
-        console.log(response)
+        console.log(`full text:\n\n${fullText}`)
       }
-      return response.content[0].text
+      return fullText
     }
   )
 }


### PR DESCRIPTION
## Problem

`@anthropic-ai/sdk` v0.68.0 rejects non-streaming requests that exceed a 10-minute estimated duration. The estimate uses:
```
expectedTime = (3600000 * max_tokens) / 128000
```

With `max_tokens=24000` → 11.25 minutes → throws `Streaming is required for operations that may take longer than 10 minutes`.

Bedrock's `InvokeModelCommand` (sync) has a 60-second service-level timeout that can also be hit for large responses.

## Changes

### anthropicExplainPatch.js
Switch from `messages.create()` to `messages.stream()` + `stream.finalText()`.

**Before:**
```js
const aiResponse = await anthropic.messages.create({ ... })
const response = aiResponse.content
return response[0].text
```

**After:**
```js
const stream = anthropic.messages.stream({ ... })
const text = await stream.finalText()
return text
```

### bedrockExplainPatch.js
Switch from `InvokeModelCommand` to `InvokeModelWithResponseStreamCommand`, collecting text from `content_block_delta` events.

**Before:**
```js
const command = new InvokeModelCommand(commandParams)
const rawResponse = await client.send(command)
const textResponse = new TextDecoder().decode(rawResponse.body)
const response = JSON.parse(textResponse)
return response.content[0].text
```

**After:**
```js
const command = new InvokeModelWithResponseStreamCommand(commandParams)
const streamResponse = await client.send(command)
let fullText = ''
for await (const chunk of streamResponse.body) {
  const decoded = new TextDecoder().decode(chunk.chunk?.bytes)
  try {
    const event = JSON.parse(decoded)
    if (event.type === 'content_block_delta' && event.delta?.type === 'text_delta') {
      fullText += event.delta.text
    }
  } catch (e) { /* skip non-JSON chunks */ }
}
return fullText
```

## Notes

- OpenAI path (`openaiExplainPatch.js`) doesn't have this streaming requirement — no change needed.
- `finalText()` joins all text content blocks with spaces — more robust than `response[0].text`.
- No changes to the trivial-skip gate (`amplification * max_tokens` threshold).