### PR TITLE
fix: bedrock stream error handling

### DIFF
--- a/src/bedrockExplainPatch.js
+++ b/src/bedrockExplainPatch.js
@@ -128,21 +128,35 @@ export default async function explainPatch ({
 
       const command = new InvokeModelWithResponseStreamCommand(commandParams)
 
-      const streamResponse = await client.send(command)
-      let fullText = ''
-      for await (const chunk of streamResponse.body) {
-        const decoded = new TextDecoder().decode(chunk.chunk?.bytes)
-        if (debug) {
-          console.log(`chunk: ${decoded}`)
+      const decoder = new TextDecoder()
+      let raw = ''
+      try {
+        const streamResponse = await client.send(command)
+        for await (const chunk of streamResponse.body) {
+          if (!chunk.chunk?.bytes) continue
+          raw += decoder.decode(chunk.chunk.bytes, { stream: true })
         }
+        raw += decoder.decode() // flush remaining multi-byte chars
+      } catch (e) {
+        throw new Error('Bedrock stream failed', { cause: e })
+      }
+      let fullText = ''
+      for (const line of raw.split('\n').filter(Boolean)) {
         try {
-          const event = JSON.parse(decoded)
+          const event = JSON.parse(line)
           if (event.type === 'content_block_delta' && event.delta?.type === 'text_delta') {
             fullText += event.delta.text
+          } else if (debug && event.type === 'message_stop') {
+            console.log(`stop reason: ${JSON.stringify(event)}`)
           }
         } catch (e) {
-          // skip non-JSON chunks
+          if (debug) {
+            console.log(`skipping non-JSON line: ${e.message}`)
+          }
         }
+      }
+      if (!fullText) {
+        throw new Error('Bedrock stream produced no text')
       }
       if (debug) {
         console.log(`full text:\n\n${fullText}`)

--- a/src/bedrockExplainPatch.js
+++ b/src/bedrockExplainPatch.js
@@ -141,7 +141,7 @@ export default async function explainPatch ({
         throw new Error('Bedrock stream failed', { cause: e })
       }
       let fullText = ''
-      for (const line of raw.split('\n').filter(Boolean)) {
+      for (const line of raw.split(/(?<=\})(?=\{)/)) {
         try {
           const event = JSON.parse(line)
           if (event.type === 'content_block_delta' && event.delta?.type === 'text_delta') {


### PR DESCRIPTION
Addresses review feedback from #385.

## Fixes

### Decoupled decode ↔ parse
Previously JSON.parse ran on each chunk while {stream: true} was active — partial multi-byte chars at chunk boundaries could be dropped. Now: accumulate raw decoded text with {stream: true} in one pass, flush decoder after loop, split into lines, parse each line cleanly.

### Split on JSON object boundaries, not newlines
Bedrock streaming returns concatenated JSON `{...}{...}` not line-delimited. Split regex `/(?<=\})(?=\{)/` extracts individual JSON objects from boundary positions.

### Stream errors surfaced with {cause}
`client.send()` and `for await` loop wrapped in try/catch. Network failures throw `Error("Bedrock stream failed", {cause: e})` preserving stack.

### Empty result throws
If `fullText` stays empty after stream completes, throws `Error("Bedrock stream produced no text")` — consistent with Anthropic path `finalText()` behavior.

### `message_stop` logged in debug mode
Previously unobservable. Now logged when `debug: true`.

### Empty chunks skipped
`if (!chunk.chunk?.bytes) continue` — avoids unnecessary decode of empty payloads.